### PR TITLE
Replace throw with revert()

### DIFF
--- a/contracts/HumanStandardToken.sol
+++ b/contracts/HumanStandardToken.sol
@@ -18,7 +18,7 @@ contract HumanStandardToken is StandardToken {
 
     function () {
         //if ether is sent to this address, send it back.
-        throw;
+        revert();
     }
 
     /* Public variables of the token */


### PR DESCRIPTION
Refer to https://github.com/ethereum/solidity/issues/2118, and https://github.com/ethereum/solidity/issues/1793

`throw` is deprecated and suggest to use `revert()` instead.