### PR TITLE
repair ABI error of bytes in calldata

### DIFF
--- a/contracts/HumanStandardToken.sol
+++ b/contracts/HumanStandardToken.sol
@@ -55,7 +55,7 @@ contract HumanStandardToken is StandardToken {
         //call the receiveApproval function on the contract you want to be notified. This crafts the function signature manually so one doesn't have to include a contract in here just for this.
         //receiveApproval(address _from, uint256 _value, address _tokenContract, bytes _extraData)
         //it is assumed that when does this that the call *should* succeed, otherwise one would use vanilla approve instead.
-        if(!_spender.call(bytes4(bytes32(sha3("receiveApproval(address,uint256,address,bytes)"))), msg.sender, _value, this, _extraData)) { throw; }
+        if(!_spender.call(bytes4(bytes32(sha3("receiveApproval(address,uint256,address,bytes)"))), abi.encode(msg.sender, _value, this, _extraData))) { throw; }
         return true;
     }
 }


### PR DESCRIPTION
address.call() function won't automatically abi-encode the calldata, of the abi-encode way dynamic type like bytes is different from fixed ones, this will cause `out of gas` error.